### PR TITLE
修复mysqli->getValue方法  limit值大于1时返回空数组

### DIFF
--- a/src/Mysqli.php
+++ b/src/Mysqli.php
@@ -544,7 +544,8 @@ class Mysqli
             return null;
         }
         $newRes = Array();
-        for ($i = 0; $i < $this->affectRows; $i++) {
+        $affectRows = count($res);
+        for ($i = 0; $i < $affectRows; $i++) {
             $newRes[] = $res[$i]['retval'];
         }
         return $newRes;


### PR DESCRIPTION
查询时 $this->affectRows = 0
改用查询结果做循环条件